### PR TITLE
Finalizado CRUD de jornadas

### DIFF
--- a/Schemas/jornadas.schema.js
+++ b/Schemas/jornadas.schema.js
@@ -1,0 +1,11 @@
+const joi = require('joi');
+const id = joi.number().integer();
+//const nombre = joi.string().min(3).max(45);
+//const descripcion = joi.string().min(3).max(255);
+//const estado = joi.boolean();
+
+const getJornadaSchema = joi.object({
+  id: id.required(),
+});
+
+module.exports = { getJornadaSchema };

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const alertaRouter = require('./routers/alerta.router');
 const proveedorRouter = require('./routers/proveedores.router');
+const jornadaRouter = require('./routers/jornadas.router');
 function routerApi(app) {
   const router = express.Router();
   app.use('/api/administracion', router);
   router.use(alertaRouter);
   router.use(proveedorRouter);
+  router.use(jornadaRouter);
 }
 
 module.exports = routerApi;

--- a/routes/routers/jornadas.router.js
+++ b/routes/routers/jornadas.router.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const JornadasController = require('../../src/controllers/jornadas.controller');
+const jornadasController = new JornadasController();
+const {
+  getJornadaSchema,
+} = require('../../Schemas/jornadas.schema');
+const validatorHandler = require('../../middlewares/validator.handler');
+
+const router = express.Router();
+
+// Obtener todas las jornadas
+router.get('/GET/jornadas', (req, res, next) => jornadasController.find(req, res, next));
+
+// Obtener una jornada por su id
+router.get('/GET/jornadas/:id',
+  validatorHandler(getJornadaSchema, 'params'),
+  (req, res, next) => jornadasController.findOne(req, res, next)
+);
+
+module.exports = router;

--- a/services/jornadas.service.js
+++ b/services/jornadas.service.js
@@ -1,0 +1,55 @@
+const boom = require('@hapi/boom');
+const { models } = require('./../config/sequelize');
+
+class JornadasService {
+  constructor () {}
+
+  async find () {
+    try {
+      const jornadas = await models.Jornada.findAll({
+        where: {
+          estado: true,
+        },
+        order: [['id', 'ASC']],
+      });
+      if (jornadas.length < 1) {
+        throw boom.notFound('No hay jornadas activas');
+      }
+      return {
+        message: 'Jornadas activas encontradas correctamente',
+        data: jornadas,
+      };
+    } catch (error) {
+      if (boom.isBoom(error)) {
+        throw error;
+      }
+      throw boom.internal(error);
+    }
+  }
+
+  async findOne (id) {
+    try {
+      const jornada = await models.Jornada.findByPk(id, {
+        where: {
+          estado: true
+        }
+      });
+
+      if (!jornada) {
+        throw boom.notFound('Jornada no encontrada');
+      }
+      if (!jornada.estado) {
+        throw boom.conflict('Jornada desactivada');
+      }
+      return {
+        message: 'Jornada encontrada correctamente',
+        data: jornada
+      };
+    } catch (error) {
+      throw boom.badRequest(error);
+    }
+  }
+
+}
+
+module.exports = JornadasService;

--- a/src/controllers/jornadas.controller.js
+++ b/src/controllers/jornadas.controller.js
@@ -1,0 +1,27 @@
+const JornadasService = require('../../services/jornadas.service');
+
+const service = new JornadasService();
+
+class JornadasController {
+
+  async find (req, res, next) {
+    try {
+      const jornadas = await service.find();
+      return res.status(200).json(jornadas);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async findOne (req, res, next) {
+    try {
+      const { id } = req.params;
+      const jornada = await service.findOne(id);
+      return res.status(200).json(jornada);
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+module.exports = JornadasController;


### PR DESCRIPTION
Endpoints funcionando:

- /GET/jornadas (listar todas las jornadas activas)
- /GET/jornadas/:id (listar una jornada activa en especifico)

Nota: Para este caso solamente se entregan endpoints para listar, ya que la creación o edición de las jornadas será por el encargado de base de datos del servicio de administración.