### PR TITLE
Save pedidos

### DIFF
--- a/Schemas/orden.schema.js
+++ b/Schemas/orden.schema.js
@@ -1,0 +1,33 @@
+const Joi = require('joi');
+
+const id = Joi.number().integer();
+const id_servicio = Joi.number().integer();
+const id_estado_orden = Joi.number().integer();
+const id_proveedor = Joi.number().integer();
+const fecha_orden = Joi.date().min('now');
+const costo_total = Joi.number().integer();
+const id_producto = Joi.number().integer();
+const cantidad = Joi.number().integer();
+const precio_unitario = Joi.number().integer();
+
+const getOrdenSchema = Joi.object({
+  id: id.required(),
+});
+
+const createOrdenSchema = Joi.object({
+  id_servicio: id_servicio.required(),
+  id_proveedor: id_proveedor.required(),
+  fecha_orden: fecha_orden.required(),
+  detalles: Joi.array().items(Joi.object({
+    id_producto: id_producto.required(),
+    cantidad: cantidad.required(),
+    precio_unitario: precio_unitario.required(),
+  })).required(),
+});
+
+module.exports = { getOrdenSchema, createOrdenSchema };
+
+
+
+
+

--- a/Schemas/orden.schema.js
+++ b/Schemas/orden.schema.js
@@ -2,13 +2,14 @@ const Joi = require('joi');
 
 const id = Joi.number().integer();
 const id_servicio = Joi.number().integer();
-const id_estado_orden = Joi.number().integer();
+const id_estado_orden = Joi.number().integer().min(1).max(4);
 const id_proveedor = Joi.number().integer();
 const fecha_orden = Joi.date().min('now');
-const costo_total = Joi.number().integer();
+//const costo_total = Joi.number().integer();
 const id_producto = Joi.number().integer();
 const cantidad = Joi.number().integer();
 const precio_unitario = Joi.number().integer();
+const estado_detalle = Joi.number().integer().valid(1, 2, 3);
 
 const getOrdenSchema = Joi.object({
   id: id.required(),
@@ -25,7 +26,20 @@ const createOrdenSchema = Joi.object({
   })).required(),
 });
 
-module.exports = { getOrdenSchema, createOrdenSchema };
+const updateOrdenSchema = Joi.object({
+  estado: id_estado_orden.required(),
+});
+
+const updateDetalleSchema = Joi.object({
+  estado: estado_detalle.required(),
+});
+
+module.exports = {
+  getOrdenSchema,
+  createOrdenSchema,
+  updateOrdenSchema,
+  updateDetalleSchema
+};
 
 
 

--- a/Schemas/orden.schema.js
+++ b/Schemas/orden.schema.js
@@ -7,7 +7,7 @@ const id_proveedor = Joi.number().integer();
 const fecha_orden = Joi.date().min('now');
 //const costo_total = Joi.number().integer();
 const id_producto = Joi.number().integer();
-const cantidad = Joi.number().integer();
+const cantidad = Joi.number().integer().positive();
 const precio_unitario = Joi.number().integer();
 const estado_detalle = Joi.number().integer().valid(1, 2, 3);
 
@@ -32,13 +32,23 @@ const updateOrdenSchema = Joi.object({
 
 const updateDetalleSchema = Joi.object({
   estado: estado_detalle.required(),
+  cantidad: Joi.when('estado', {
+    is: 2,
+    then: cantidad.required(),
+    otherwise: Joi.forbidden()
+  })
+});
+
+const reabastecerOrdenSchema = Joi.object({
+  id: id.required()
 });
 
 module.exports = {
   getOrdenSchema,
   createOrdenSchema,
   updateOrdenSchema,
-  updateDetalleSchema
+  updateDetalleSchema,
+  reabastecerOrdenSchema
 };
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
+        "axios": "^1.8.4",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
@@ -554,6 +555,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -562,6 +569,17 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -801,6 +819,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -922,6 +952,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -1100,6 +1139,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1667,6 +1721,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1682,6 +1756,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -1888,6 +1977,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2942,6 +3046,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "dev": "nodemon index.js",
     "start": "node index.js",
     "lint": "eslint",
-      "migrations:generate": "sequelize-cli migration:generate --name",
+    "migrations:generate": "sequelize-cli migration:generate --name",
     "migrations:run": "sequelize-cli db:migrate",
-    "migrations:revert" : "sequelize-cli db:migrate:undo",
-    "migrations:delete" : "sequelize-cli db:migrate:undo:all",
+    "migrations:revert": "sequelize-cli db:migrate:undo",
+    "migrations:delete": "sequelize-cli db:migrate:undo:all",
     "seed:generate": "sequelize-cli seed:generate --name",
     "seed:run": "sequelize-cli db:seed:all"
   },
@@ -27,6 +27,7 @@
   "description": "",
   "dependencies": {
     "@hapi/boom": "^10.0.1",
+    "axios": "^1.8.4",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const alertaRouter = require('./routers/alerta.router');
 const proveedorRouter = require('./routers/proveedores.router');
+const orderRouter = require('./routers/orden.router');
 function routerApi(app) {
   const router = express.Router();
   app.use('/api/administracion', router);
   router.use(alertaRouter);
   router.use(proveedorRouter);
+  router.use(orderRouter);
 }
 
 module.exports = routerApi;

--- a/routes/routers/orden.router.js
+++ b/routes/routers/orden.router.js
@@ -2,7 +2,7 @@ const express = require('express');
 const OrdenController = require('./../../src/controllers/orden.controller');
 const ordenController = new OrdenController();
 
-const { getOrdenSchema, createOrdenSchema } = require('./../../Schemas/orden.schema');
+const { getOrdenSchema, createOrdenSchema, updateOrdenSchema, updateDetalleSchema } = require('./../../Schemas/orden.schema');
 const validatorHandler = require('./../../middlewares/validator.handler');
 
 const router = express.Router();
@@ -20,6 +20,20 @@ router.get('/GET/ordenes/:id',
 router.post('/POST/ordenes',
   validatorHandler(createOrdenSchema, 'body'),
   (req, res, next) => ordenController.create(req, res, next)
+);
+
+//Actualizar estado de una orden
+router.put('/PUT/ordenes/modificar_estado/:id',
+  validatorHandler(getOrdenSchema, 'params'),
+  validatorHandler(updateOrdenSchema, 'body'),
+  (req, res, next) => ordenController.update(req, res, next)
+);
+
+//Actualizar estado de un detalle de orden
+router.put('/PUT/ordenes/detalle/:id',
+  validatorHandler(getOrdenSchema, 'params'),
+  validatorHandler(updateDetalleSchema, 'body'),
+  (req, res, next) => ordenController.updateDetalleEstado(req, res, next)
 );
 
 module.exports = router;

--- a/routes/routers/orden.router.js
+++ b/routes/routers/orden.router.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const OrdenController = require('./../../src/controllers/orden.controller');
+const ordenController = new OrdenController();
+
+const { getOrdenSchema, createOrdenSchema } = require('./../../Schemas/orden.schema');
+const validatorHandler = require('./../../middlewares/validator.handler');
+
+const router = express.Router();
+
+//Obtener todas las ordenes
+router.get('/GET/ordenes', (req, res, next) => ordenController.find(req, res, next));
+
+//Obtener una orden por su id
+router.get('/GET/ordenes/:id',
+  validatorHandler(getOrdenSchema, 'params'),
+  (req, res, next) => ordenController.findOne(req, res, next)
+);
+
+//Crear una orden
+router.post('/POST/ordenes',
+  validatorHandler(createOrdenSchema, 'body'),
+  (req, res, next) => ordenController.create(req, res, next)
+);
+
+module.exports = router;

--- a/routes/routers/orden.router.js
+++ b/routes/routers/orden.router.js
@@ -2,7 +2,7 @@ const express = require('express');
 const OrdenController = require('./../../src/controllers/orden.controller');
 const ordenController = new OrdenController();
 
-const { getOrdenSchema, createOrdenSchema, updateOrdenSchema, updateDetalleSchema } = require('./../../Schemas/orden.schema');
+const { getOrdenSchema, createOrdenSchema, updateOrdenSchema, updateDetalleSchema, reabastecerOrdenSchema } = require('./../../Schemas/orden.schema');
 const validatorHandler = require('./../../middlewares/validator.handler');
 
 const router = express.Router();
@@ -34,6 +34,12 @@ router.put('/PUT/ordenes/detalle/:id',
   validatorHandler(getOrdenSchema, 'params'),
   validatorHandler(updateDetalleSchema, 'body'),
   (req, res, next) => ordenController.updateDetalleEstado(req, res, next)
+);
+
+//Reabastecer una orden
+router.post('/POST/ordenes/reabastecer/:id',
+  validatorHandler(reabastecerOrdenSchema, 'params'),
+  (req, res, next) => ordenController.reabastecer(req, res, next)
 );
 
 module.exports = router;

--- a/services/orden.service.js
+++ b/services/orden.service.js
@@ -1,0 +1,99 @@
+const boom = require('@hapi/boom');
+const { models } = require('./../config/sequelize');
+
+class OrdenService {
+  constructor() {}
+
+  async find(){
+    try {
+      const ordenes = await models.Orden.findAll({
+        order: [['idmodels', 'ASC']],
+      });
+      if (ordenes.length < 1) {
+        throw boom.notFound('No hay ordenes');
+      }
+      return {
+        message: 'Ordenes activas encontradas correctamente',
+        data: ordenes,
+      };
+    } catch (error) {
+      if (boom.isBoom(error)) {
+        throw error;
+      }
+      throw boom.internal(error);
+    }
+  }
+
+  async findOne(id){
+    try {
+      const orden = await models.Orden.findByPk(id);
+      if (!orden) {
+        throw boom.notFound('Orden no encontrada');
+      }
+      return {
+        message: 'Orden encontrada correctamente',
+        data: orden,
+      };
+    } catch (error) {
+      if (boom.isBoom(error)) {
+        throw error;
+      }
+      throw boom.internal(error);
+    }
+  }
+
+  async create(data){
+    // Iniciar una transacción
+    const transaction = await models.Orden.sequelize.transaction();
+    try {
+      const { detalles } = data;
+      let sumaTotal = 0;
+
+      // Crear la orden
+      const newOrden = await models.Orden.create({
+        id_servicio: data.id_servicio,
+        id_proveedor: data.id_proveedor,
+        fecha_orden: data.fecha_orden,
+        costo_total: 0,
+        id_estado_orden: 1,
+      }, { transaction });
+
+      // Crear los detalles de la orden
+      await Promise.all(detalles.map(async (detalle) => {
+        await models.OrdenDetalle.create({
+          id_orden: newOrden.id,
+          id_producto: detalle.id_producto,
+          id_estado_detalle: 3,
+          cantidad: detalle.cantidad,
+          precio_unitario: detalle.precio_unitario
+        }, { transaction });
+        sumaTotal += detalle.precio_unitario * detalle.cantidad;
+      }));
+
+      await models.Orden.update({
+        costo_total: sumaTotal
+      }, {
+        where: { id: newOrden.id },
+        transaction
+      });
+
+      // Si todo sale bien hacer commit de la transacción
+      await transaction.commit();
+
+      return {
+        message: 'Orden creada correctamente',
+        data: newOrden,
+      };
+    } catch (error) {
+      // Para caso de error se hace un rollback de la transacción
+      await transaction.rollback();
+
+      if (boom.isBoom(error)) {
+        throw error;
+      }
+      throw boom.internal(error);
+    }
+  }
+}
+
+module.exports = OrdenService;

--- a/services/proveedor.service.js
+++ b/services/proveedor.service.js
@@ -52,7 +52,10 @@ class ProveedorService {
       if (!proveedor.estado) {
         throw boom.conflict('Proveedor desactivado');
       }
-      return proveedor;
+      return {
+        message: 'Proveedor encontrado correctamente',
+        data: proveedor,
+      };
     } catch (error) {
       if (boom.isBoom(error)) {
         throw error;

--- a/src/controllers/orden.controller.js
+++ b/src/controllers/orden.controller.js
@@ -49,6 +49,16 @@ class OrdenController {
       next(error);
     }
   }
+
+  async reabastecer(req, res, next) {
+    try {
+      const { id } = req.params;
+      const orden = await service.reabastecer(id);
+      res.status(200).json(orden);
+    } catch (error) {
+      next(error);
+    }
+  }
 }
 
 module.exports = OrdenController;

--- a/src/controllers/orden.controller.js
+++ b/src/controllers/orden.controller.js
@@ -29,6 +29,26 @@ class OrdenController {
       next(error);
     }
   }
+
+  async update(req, res, next) {
+    try {
+      const { id } = req.params;
+      const orden = await service.update(id, req.body);
+      res.status(200).json(orden);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async updateDetalleEstado(req, res, next) {
+    try {
+      const { id } = req.params;
+      const detalle = await service.updateDetalleEstado(id, req.body);
+      res.status(200).json(detalle);
+    } catch (error) {
+      next(error);
+    }
+  }
 }
 
 module.exports = OrdenController;

--- a/src/controllers/orden.controller.js
+++ b/src/controllers/orden.controller.js
@@ -1,0 +1,34 @@
+const OrdenService = require('./../../services/orden.service');
+
+const service = new OrdenService();
+
+class OrdenController {
+  async find(req, res, next) {
+    try {
+      const ordenes = await service.find();
+      res.status(200).json(ordenes);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async findOne(req, res, next) {
+    try {
+      const orden = await service.findOne(req.params.id);
+      res.status(200).json(orden);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async create(req, res, next) {
+    try {
+      const orden = await service.create(req.body);
+      res.status(201).json(orden);
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+module.exports = OrdenController;

--- a/src/models/orden_detalle.model.js
+++ b/src/models/orden_detalle.model.js
@@ -48,7 +48,8 @@ const OrdenDetalleSchema = {
     type: DataTypes.DATE,
     defaultValue: Sequelize.NOW,
   },
-  updateAt: {
+  updatedAt: {
+    field: 'updateAt',
     allowNull: true,
     type: DataTypes.DATE,
   },
@@ -60,9 +61,9 @@ class OrdenDetalle extends Model {
       as: 'orden',
       foreignKey: 'id_orden',
     });
-    this.belongsTo(models.EstadoOrden, {
-      as: 'estado_orden',
-      foreignKey: 'id_estado_orden',
+    this.belongsTo(models.EstadoDetalle, {
+      as: 'estado_detalle',
+      foreignKey: 'id_estado_detalle',
     });
   }
 


### PR DESCRIPTION
CRUD para guardar y gestionar las ordenes de reabastecimiento
Se agregaron los endpoints para obtener las ordenes y obtener una orden especifica con su detalle

Se agrego un endpoint para guardar y crear una nueva orden junto con los datos de su detalle

Se agrego un endpoint para cambiar el estado de  una orden, agregando validaciones para realizar cambios de ordenes validos al igual que el cambio de los estados de los detalles

Se agrego un endpoint para mandar a reabastecer una orden en donde consulta a los endpoints de los demas servicios para reabastecerlos de manera manual cuando se confirme el estado de la orden